### PR TITLE
Remove pmdl_file parameter on settings.yml

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -15,8 +15,8 @@ default_trigger: "snowboy"
 # - snowboy
 triggers:
   - snowboy:
-      pmdl_file: "trigger/kalliope-FR-90samples.pmdl"
-
+      keywords:
+        - file_path: "trigger/kalliope-FR-90samples.pmdl"
 
 # ---------------------------
 # Speech to text


### PR DESCRIPTION
I have setup a fresh installation of Kalliope version 0.7.0.
When I start Kalliope with this starter_kit, I obtain this error :
```
Exception in thread <class 'kalliope.signals.order.order.Order'>:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.7/dist-packages/kalliope-0.7.0-py3.7.egg/kalliope/signals/order/order.py", line 89, in run
    self.start_trigger()
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 390, in trigger
    return self.machine._process(func)
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 1127, in _process
    self._transition_queue[0]()
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 408, in _trigger
    return self._process(event_data)
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 417, in _process
    if trans.execute(event_data):
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 269, in execute
    self._change_state(event_data)
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 279, in _change_state
    event_data.machine.get_state(self.dest).enter(event_data)
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 121, in enter
    event_data.machine.callbacks(self.on_enter, event_data)
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 1049, in callbacks
    self.callback(func, event_data)
  File "/usr/local/lib/python3.7/dist-packages/transitions-0.8.2-py3.7.egg/transitions/core.py", line 1070, in callback
    func(*event_data.args, **event_data.kwargs)
  File "/usr/local/lib/python3.7/dist-packages/kalliope-0.7.0-py3.7.egg/kalliope/signals/order/order.py", line 96, in start_trigger_process
    self.trigger_instance = TriggerLauncher.get_trigger(settings=self.settings, callback=self.trigger_callback)
  File "/usr/local/lib/python3.7/dist-packages/kalliope-0.7.0-py3.7.egg/kalliope/core/TriggerLauncher.py", line 35, in get_trigger
    resources_dir=trigger_folder)
  File "/usr/local/lib/python3.7/dist-packages/kalliope-0.7.0-py3.7.egg/kalliope/core/Utils/Utils.py", line 140, in get_dynamic_class_instantiation
    return klass(**parameters)
  File "/usr/local/lib/python3.7/dist-packages/kalliope-0.7.0-py3.7.egg/kalliope/trigger/snowboy/snowboy.py", line 44, in __init__
    raise MissingParameterException('"pmdl_file" parameter is deprecated, please update your snowboy settings. \n Visit https://kalliope-project.github.io/kalliope/settings/triggers/snowboy/ for more information.')
kalliope.trigger.snowboy.snowboy.MissingParameterException: "pmdl_file" parameter is deprecated, please update your snowboy settings. 
 Visit https://kalliope-project.github.io/kalliope/settings/triggers/snowboy/ for more information.
```
I have corrected the settings.yml file to correct this error.